### PR TITLE
Add function to retrieve metadata from Nextstrain's ncov pipeline run at a specific point in time

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Once the package is installed, you can instantiate a `CladeTime` object in a Pyt
 #### Work with the latest Nextstrain Sars-Cov-2 sequence metadata and clade assignments
 
 ```python
-In [1]: from virus_clade_utils.clade_time import CladeTime
+In [1]: from virus_clade_utils.cladetime import CladeTime
 
 In [2]: ct = CladeTime()
 
@@ -55,7 +55,7 @@ Out[4]:
  #### Work with point-in-time Nextstrain Sars-Cov-2 sequence metadata and clade assignments
 
  ```python
-In [5]: from virus_clade_utils.clade_time import CladeTime
+In [5]: from virus_clade_utils.cladetime import CladeTime
 
 In [6]: ct = CladeTime(sequence_as_of="2024-08-31", tree_as_of="2024-08-01")
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,66 @@ We are releasing `virus-clade-utils` as a standalone package for use by others w
 
 ## Usage
 
-TODO: Actual documentation
+This library contains two types of components:
+
+1. Scripts and CLI tools for use in database pipelinnes required by the Variant Nowcast Hub
+(these are in development and not documented here).
+
+2. A CladeTime class for interactively working with Sars-Cov-2 sequence and clade data as of a specific date.
+
+### Sample CladeTime usage
+
+To use the interactive `CladeTime` object, install this package:
+
+```bash
+    pip install git+https://github.com/reichlab/virus-clade-utils.git
+```
+
+Once the package is installed, you can instantiate a `CladeTime` object in a Python console
+(see some examples below).
+
+#### Work with the latest Nextstrain Sars-Cov-2 sequence metadata and clade assignments
+
+```python
+In [1]: from virus_clade_utils.clade_time import CladeTime
+
+In [2]: ct = CladeTime()
+
+# URL for the corresponding Nextstrain Sars-Cov-2 sequence metadata
+In [3]: ct.url_sequence_metadata
+Out[3]: 'https://nextstrain-data.s3.amazonaws.com/files/ncov/open/metadata.tsv.zst?versionId=VJomXHLN2L9aqvS9Ax_LJ4ecr5ZsFFhE'
+
+# Metadata from the pipeline that produced the above file
+In [4]: ct.ncov_metadata
+Out[4]:
+{'schema_version': 'v1',
+ 'nextclade_version': 'nextclade 3.8.2',
+ 'nextclade_dataset_name': 'SARS-CoV-2',
+ 'nextclade_dataset_version': '2024-09-25--21-50-30Z',
+ 'nextclade_tsv_sha256sum': 'fbe579554e925e4dfaf74cfb4e72b52c702e671f0f0374d896f1e30ae4fe5566',
+ 'metadata_tsv_sha256sum': '5a4fd84a5cd3c4ead9cf730d4df10b8734898c6c3e0cae1c8c0acf432325d22c'}
+ ```
+
+ #### Work with point-in-time Nextstrain Sars-Cov-2 sequence metadata and clade assignments
+
+ ```python
+In [5]: from virus_clade_utils.clade_time import CladeTime
+
+In [6]: ct = CladeTime(sequence_as_of="2024-08-31", tree_as_of="2024-08-01")
+
+# URL for the corresponding Nextstrain Sars-Cov-2 sequence metadata as it existing on 2024-08-31
+In [7]: ct.url_sequence_metadata
+Out[7]: 'https://nextstrain-data.s3.amazonaws.com/files/ncov/open/metadata.tsv.zst?versionId=1SZMfjWxXjNy530F6L7MfyflUCbue.JD'
+
+# Metadata for the pipeline run that produced the above file
+In [8]: ct.ncov_metadata
+Out[8]: {'schema_version': 'v1',
+ 'nextclade_version': 'nextclade 3.8.2',
+ 'nextclade_dataset_name': 'SARS-CoV-2',
+ 'nextclade_dataset_version': '2024-07-17--12-57-03Z',
+ 'nextclade_tsv_sha256sum': 'fd30f0b258f73fdcf5acefe77937ebe7d88862093bb4aaf3a7e935650ccea060',
+ 'metadata_tsv_sha256sum': '898451d9750128b4f90253d91cef0092e51965e879536e80aa6598de0fd4af29'}
+```
 
 
 ## Docker Setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "rich",
     "rich-click",
     "structlog",
-    "us"
+    "urllib3",
+    "us",
 ]
 
 [project.optional-dependencies]
@@ -62,4 +63,7 @@ lint.extend-select = ["I"]
 
 [tools.setuptools]
 packages = ["virus_clade_utils"]
+
+[tool.mypy]
+ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest",
     "pytest-mock",
     "ruff",
+    "types-python-dateutil",
     "types-requests",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dev = [
     "types-requests",
 ]
 
+[project.urls]
+Repository = "https://github.com/reichlab/virus-clade-utils.git"
+
 [project.entry-points."console_scripts"]
 assign_clades = "virus_clade_utils.assign_clades:main"
 clade_list = "virus_clade_utils.get_clade_list:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "boto3-stubs[s3]",
     "coverage",
     "freezegun",
     "moto",
@@ -36,6 +37,7 @@ dev = [
     "pytest",
     "pytest-mock",
     "ruff",
+    "types-requests",
 ]
 
 [project.entry-points."console_scripts"]
@@ -59,3 +61,4 @@ lint.extend-select = ["I"]
 
 [tools.setuptools]
 packages = ["virus_clade_utils"]
+

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -131,6 +131,8 @@ structlog==24.2.0
     # via virus-clade-utils (pyproject.toml)
 types-awscrt==0.21.5
     # via botocore-stubs
+types-python-dateutil==2.9.0.20240906
+    # via virus-clade-utils (pyproject.toml)
 types-requests==2.32.0.20240914
     # via virus-clade-utils (pyproject.toml)
 types-s3transfer==0.10.2

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -145,6 +145,7 @@ tzdata==2024.1
     # via pandas
 urllib3==2.2.1
     # via
+    #   virus-clade-utils (pyproject.toml)
     #   botocore
     #   requests
     #   responses

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -6,12 +6,16 @@ boto3==1.34.116
     # via
     #   virus-clade-utils (pyproject.toml)
     #   moto
+boto3-stubs==1.35.28
+    # via virus-clade-utils (pyproject.toml)
 botocore==1.34.116
     # via
     #   awscli
     #   boto3
     #   moto
     #   s3transfer
+botocore-stubs==1.35.28
+    # via boto3-stubs
 certifi==2024.2.2
     # via requests
 cffi==1.17.1
@@ -58,6 +62,8 @@ moto==5.0.15
     # via virus-clade-utils (pyproject.toml)
 mypy==1.10.1
     # via virus-clade-utils (pyproject.toml)
+mypy-boto3-s3==1.35.22
+    # via boto3-stubs
 mypy-extensions==1.0.0
     # via mypy
 numpy==1.26.4
@@ -123,6 +129,12 @@ six==1.16.0
     # via python-dateutil
 structlog==24.2.0
     # via virus-clade-utils (pyproject.toml)
+types-awscrt==0.21.5
+    # via botocore-stubs
+types-requests==2.32.0.20240914
+    # via virus-clade-utils (pyproject.toml)
+types-s3transfer==0.10.2
+    # via boto3-stubs
 typing-extensions==4.12.0
     # via
     #   mypy
@@ -134,6 +146,7 @@ urllib3==2.2.1
     #   botocore
     #   requests
     #   responses
+    #   types-requests
 us==3.2.0
     # via virus-clade-utils (pyproject.toml)
 werkzeug==3.0.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -81,6 +81,7 @@ tzdata==2024.1
     # via pandas
 urllib3==2.2.1
     # via
+    #   virus-clade-utils (pyproject.toml)
     #   botocore
     #   requests
 us==3.2.0

--- a/src/virus_clade_utils/assign_clades.py
+++ b/src/virus_clade_utils/assign_clades.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import datetime
 import os
 import subprocess

--- a/src/virus_clade_utils/assign_clades.py
+++ b/src/virus_clade_utils/assign_clades.py
@@ -11,9 +11,9 @@ import structlog
 from virus_clade_utils.util.config import Config
 from virus_clade_utils.util.reference import get_nextclade_dataset
 from virus_clade_utils.util.sequence import (
+    _unzip_sequence_package,
     get_covid_genome_data,
     parse_sequence_assignments,
-    unzip_sequence_package,
 )
 
 logger = structlog.get_logger()
@@ -41,7 +41,7 @@ def get_sequences(config: Config):
     sequence_released_datetime = sequence_released_date.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 
     get_covid_genome_data(sequence_released_datetime, base_url=config.ncbi_base_url, filename=sequence_package)
-    unzip_sequence_package(sequence_package, config.data_path)
+    _unzip_sequence_package(sequence_package, config.data_path)
 
     logger.info("NCBI SARS-COV-2 genome package downloaded and unzipped", package_location=sequence_package)
 

--- a/src/virus_clade_utils/assign_clades.py
+++ b/src/virus_clade_utils/assign_clades.py
@@ -19,13 +19,13 @@ from virus_clade_utils.util.sequence import (
 logger = structlog.get_logger()
 
 
-def setup_config(base_data_dir: str, sequence_released_date: datetime, reference_tree_as_of_date: datetime) -> Config:
+def setup_config(base_data_dir: str, sequence_released_date: datetime, tree_as_of_date: datetime) -> Config:
     """Return an initialized Config class for the pipeline run."""
 
     config = Config(
         data_path_root=base_data_dir,
         sequence_released_date=sequence_released_date,
-        reference_tree_as_of_date=reference_tree_as_of_date,
+        tree_as_of_date=tree_as_of_date,
     )
 
     return config

--- a/src/virus_clade_utils/cladetime.py
+++ b/src/virus_clade_utils/cladetime.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 import structlog
 
 from virus_clade_utils.exceptions import CladeTimeInvalidDateError
+from virus_clade_utils.util.config import Config
+from virus_clade_utils.util.reference import _get_s3_object_url
 
 logger = structlog.get_logger()
 
@@ -48,8 +50,32 @@ class CladeTime:
             "YYYY-MM-DD", or None (which defaults to the current date and time).
         """
 
+        self._config = self._get_config()
         self.sequence_as_of = self._validate_as_of_date(sequence_as_of)
         self.tree_as_of = self._validate_as_of_date(tree_as_of)
+
+        self.url_sequence = _get_s3_object_url(
+            self._config.nextstrain_ncov_bucket, self._config.nextstrain_genome_sequence_key, self.sequence_as_of
+        )[1]
+        self.url_sequence_metadata = _get_s3_object_url(
+            self._config.nextstrain_ncov_bucket, self._config.nextstrain_genome_metadata_key, self.sequence_as_of
+        )[1]
+
+        # Nextstrain began publishing ncov pipeline metadata starting on 2024-08-01
+        if self.sequence_as_of >= self._config.nextstrain_min_ncov_metadata_date:
+            self.url_ncov_metadata = _get_s3_object_url(
+                self._config.nextstrain_ncov_bucket, self._config.nextstrain_ncov_metadata_key, self.sequence_as_of
+            )[1]
+        else:
+            self.url_ncov_metadata = None
+
+    def _get_config(self) -> Config:
+        """Return a config object."""
+        # dates passed to Config don't actually do anything in this case
+        # (config needs a refactor)
+        config = Config(datetime.now(), datetime.now())
+
+        return config
 
     def _validate_as_of_date(self, as_of: str) -> datetime:
         """Validate date the as_of dates used to instantiate CladeTime."""
@@ -64,7 +90,7 @@ class CladeTime:
                 raise CladeTimeInvalidDateError(f"Invalid date string: {as_of} (should be in YYYY-MM-DD format)") from e
 
         as_of_date = as_of_date.replace(microsecond=0, tzinfo=timezone.utc)
-        if as_of_date < datetime(2023, 5, 1).replace(tzinfo=timezone.utc):
+        if as_of_date < self._config.nextstrain_min_seq_date:
             raise CladeTimeInvalidDateError(f"Date must be after May 1, 2023: {as_of_date}")
 
         if as_of_date > datetime.now().replace(tzinfo=timezone.utc):

--- a/src/virus_clade_utils/cladetime.py
+++ b/src/virus_clade_utils/cladetime.py
@@ -88,6 +88,12 @@ class CladeTime:
             metadata = {}
         return metadata
 
+    def __repr__(self):
+        return f"CladeTime(sequence_as_of={self.sequence_as_of}, tree_as_of={self.tree_as_of})"
+
+    def __str__(self):
+        return f"Work with Nextstrain Sara-CoV-2 sequences as of {self.sequence_as_of} and Nextclade clade assignments as of {self.tree_as_of}"
+
     def _get_config(self) -> Config:
         """Return a config object."""
         # dates passed to Config don't actually do anything in this case

--- a/src/virus_clade_utils/exceptions.py
+++ b/src/virus_clade_utils/exceptions.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for cladetime."""
+
+
+class Error(Exception):
+    """Base class for exceptions raised by cladetime."""
+
+
+class CladeTimeInvalidDateError(Error):
+    """Raised when an invalid date string is passed to CladeTime."""

--- a/src/virus_clade_utils/get_clade_list.py
+++ b/src/virus_clade_utils/get_clade_list.py
@@ -15,7 +15,7 @@ from virus_clade_utils.util.sequence import (
     get_clade_counts,
     get_covid_genome_metadata,
 )
-from virus_clade_utils.util.session import get_session
+from virus_clade_utils.util.session import _get_session
 
 logger = structlog.get_logger()
 
@@ -103,7 +103,7 @@ def main(
     list of strings
     """
     os.makedirs(data_dir, exist_ok=True)
-    session = get_session()
+    session = _get_session()
     genome_metadata_path = download_covid_genome_metadata(
         session,
         genome_metadata_bucket,

--- a/src/virus_clade_utils/util/config.py
+++ b/src/virus_clade_utils/util/config.py
@@ -1,7 +1,7 @@
 # mypy: ignore-errors
 
 from dataclasses import InitVar, asdict, dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pprint import pprint
 
 from cloudpathlib import AnyPath
@@ -20,8 +20,17 @@ class Config:
     ncbi_package_name: str = "ncbi.zip"
     ncbi_sequence_file: AnyPath = None
     ncbi_sequence_metadata_file: AnyPath = None
+
+    # Nextstrain sequence data files in their current format is published back to 2023-05-01
+    nextstrain_min_seq_date: datetime = datetime(2023, 5, 1).replace(tzinfo=timezone.utc)
+
+    # Nextstrain ncov pipeline metadata began publishing on 2024-08-01
+    nextstrain_min_ncov_metadata_date: datetime = datetime(2024, 8, 1, 1, 26, 29, tzinfo=timezone.utc)
+
     nextstrain_ncov_bucket = "nextstrain-data"
+    nextstrain_ncov_metadata_key = "files/ncov/open/metadata_version.json"
     nextstrain_genome_metadata_key = "files/ncov/open/metadata.tsv.zst"
+    nextstrain_genome_sequence_key = "files/ncov/open/sequences.fasta.zst"
     nextclade_base_url: str = "https://nextstrain.org/nextclade/sars-cov-2"
     reference_tree_file: AnyPath = None
     root_sequence_file: AnyPath = None

--- a/src/virus_clade_utils/util/config.py
+++ b/src/virus_clade_utils/util/config.py
@@ -10,7 +10,7 @@ from cloudpathlib import AnyPath
 @dataclass
 class Config:
     sequence_released_date: InitVar[datetime]
-    reference_tree_as_of_date: InitVar[datetime]
+    tree_as_of_date: InitVar[datetime]
     data_path_root: InitVar[str] = AnyPath(".")
     sequence_released_since_date: str = None
     reference_tree_date: str = None
@@ -32,7 +32,7 @@ class Config:
     def __post_init__(
         self,
         sequence_released_date: datetime,
-        reference_tree_as_of_date: datetime,
+        tree_as_of_date: datetime,
         data_path_root: str | None,
     ):
         if data_path_root:
@@ -40,7 +40,7 @@ class Config:
         else:
             self.data_path = AnyPath(".").home() / "covid_variant" / self.run_time
         self.sequence_released_since_date = sequence_released_date.strftime("%Y-%m-%d")
-        self.reference_tree_date = reference_tree_as_of_date.strftime("%Y-%m-%d")
+        self.reference_tree_date = tree_as_of_date.strftime("%Y-%m-%d")
         self.ncbi_sequence_file = self.data_path / "ncbi_dataset/data/genomic.fna"
         self.ncbi_sequence_metadata_file = self.data_path / f"{self.sequence_released_since_date}-metadata.tsv"
         self.reference_tree_file = self.data_path / f"{self.reference_tree_date}_tree.json"

--- a/src/virus_clade_utils/util/config.py
+++ b/src/virus_clade_utils/util/config.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 from dataclasses import InitVar, asdict, dataclass, field
 from datetime import datetime
 from pprint import pprint
@@ -29,8 +31,8 @@ class Config:
 
     def __post_init__(
         self,
-        sequence_released_date: datetime.date,
-        reference_tree_as_of_date: datetime.date,
+        sequence_released_date: datetime,
+        reference_tree_as_of_date: datetime,
         data_path_root: str | None,
     ):
         if data_path_root:

--- a/src/virus_clade_utils/util/reference.py
+++ b/src/virus_clade_utils/util/reference.py
@@ -47,7 +47,7 @@ def get_nextclade_dataset(as_of_date: str, data_path_root: str) -> Path:
     return DATASET_PATH
 
 
-def get_s3_object_url(bucket_name: str, object_key: str, date: datetime) -> Tuple[str, str]:
+def _get_s3_object_url(bucket_name: str, object_key: str, date: datetime) -> Tuple[str, str]:
     """
     For a versioned, public S3 bucket and object key, return the version ID
     of the object as it existed at a specific date (UTC)

--- a/src/virus_clade_utils/util/reference.py
+++ b/src/virus_clade_utils/util/reference.py
@@ -13,7 +13,7 @@ from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
 logger = structlog.get_logger()
 
 
-def get_nextclade_dataset(as_of_date: str, data_path_root: str) -> str:
+def get_nextclade_dataset(as_of_date: str, data_path_root: str) -> Path:
     """
     Return the Nextclade dataset relevant to a specified as_of_date. The dataset is
     in .zip format and contains two components required for assignming virus
@@ -53,7 +53,7 @@ def get_s3_object_url(bucket_name: str, object_key: str, date: datetime) -> Tupl
     of the object as it existed at a specific date (UTC)
     """
     try:
-        s3_client = boto3.client("s3", config=boto3.session.Config(signature_version=UNSIGNED))
+        s3_client = boto3.client("s3", config=boto3.session.Config(signature_version=UNSIGNED))  # type: ignore
 
         paginator = s3_client.get_paginator("list_object_versions")
         page_iterator = paginator.paginate(Bucket=bucket_name, Prefix=object_key)

--- a/src/virus_clade_utils/util/sequence.py
+++ b/src/virus_clade_utils/util/sequence.py
@@ -12,8 +12,8 @@ import structlog
 import us  # type: ignore
 from requests import Session
 
-from virus_clade_utils.util.reference import get_s3_object_url
-from virus_clade_utils.util.session import check_response, get_session
+from virus_clade_utils.util.reference import _get_s3_object_url
+from virus_clade_utils.util.session import _check_response, _get_session
 
 logger = structlog.get_logger()
 
@@ -28,7 +28,7 @@ def get_covid_genome_data(released_since_date: str, base_url: str, filename: str
     headers = {
         "Accept": "application/zip",
     }
-    session = get_session()
+    session = _get_session()
     session.headers.update(headers)
 
     # TODO: this might be a better as an item in the forthcoming config file
@@ -50,7 +50,7 @@ def get_covid_genome_data(released_since_date: str, base_url: str, filename: str
 
     start = time.perf_counter()
     response = session.post(base_url, data=json.dumps(request_body), timeout=(300, 300))
-    check_response(response)
+    _check_response(response)
 
     # Originally tried saving the NCBI package via a stream call and iter_content (to prevent potential
     # memory issues that can arise when download large files). However, ran into an intermittent error:
@@ -76,7 +76,7 @@ def download_covid_genome_metadata(
     else:
         as_of_datetime = datetime.strptime(as_of, "%Y-%m-%d").replace(tzinfo=timezone.utc)
 
-    (s3_version, s3_url) = get_s3_object_url(bucket, key, as_of_datetime)
+    (s3_version, s3_url) = _get_s3_object_url(bucket, key, as_of_datetime)
     filename = data_path / f"{as_of_datetime.date().strftime('%Y-%m-%d')}-{Path(key).name}"
 
     if use_existing and filename.exists():
@@ -162,7 +162,7 @@ def get_clade_counts(filtered_metadata: pl.LazyFrame) -> pl.LazyFrame:
     return counts
 
 
-def unzip_sequence_package(filename: Path, data_path: Path):
+def _unzip_sequence_package(filename: Path, data_path: Path):
     """Unzip the downloaded virus genome data package."""
     with zipfile.ZipFile(filename, "r") as package_zip:
         zip_contents = package_zip.namelist()

--- a/src/virus_clade_utils/util/sequence.py
+++ b/src/virus_clade_utils/util/sequence.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import polars as pl
 import structlog
-import us  # type: ignore
+import us
 from requests import Session
 
 from virus_clade_utils.util.reference import _get_s3_object_url

--- a/src/virus_clade_utils/util/sequence.py
+++ b/src/virus_clade_utils/util/sequence.py
@@ -11,6 +11,7 @@ import polars as pl
 import structlog
 import us  # type: ignore
 from requests import Session
+
 from virus_clade_utils.util.reference import get_s3_object_url
 from virus_clade_utils.util.session import check_response, get_session
 
@@ -161,7 +162,7 @@ def get_clade_counts(filtered_metadata: pl.LazyFrame) -> pl.LazyFrame:
     return counts
 
 
-def unzip_sequence_package(filename: str, data_path: str):
+def unzip_sequence_package(filename: Path, data_path: Path):
     """Unzip the downloaded virus genome data package."""
     with zipfile.ZipFile(filename, "r") as package_zip:
         zip_contents = package_zip.namelist()
@@ -188,6 +189,6 @@ def parse_sequence_assignments(df_assignments: pl.DataFrame) -> pl.DataFrame:
         raise ValueError("Clade assignment data contains duplicate sequence. Stopping assignment process.")
 
     # add the parsed sequence number as a new column
-    df_assignments = df_assignments.insert_column(1, seq)
+    df_assignments = df_assignments.insert_column(1, seq)  # type: ignore
 
     return df_assignments

--- a/src/virus_clade_utils/util/sequence.py
+++ b/src/virus_clade_utils/util/sequence.py
@@ -111,6 +111,28 @@ def get_covid_genome_metadata(metadata_path: Path, num_rows: int | None = None) 
     return metadata
 
 
+def _get_ncov_metadata(
+    url_ncov_metadata: str,
+    session: Session | None = None,
+) -> dict:
+    """Return metadata emitted by the Nextstrain ncov pipeline."""
+    if not session:
+        session = _get_session(retry=False)
+
+    response = session.get(url_ncov_metadata)
+    if not response.ok:
+        logger.warn(
+            "Failed to retrieve ncov metadata",
+            status_code=response.status_code,
+            response_text=response.text,
+            request=response.request.url,
+            request_body=response.request.body,
+        )
+        return {}
+
+    return response.json()
+
+
 def filter_covid_genome_metadata(metadata: pl.LazyFrame, cols: list = []) -> pl.LazyFrame:
     """Apply a standard set of filters to the GenBank genome metadata."""
 

--- a/src/virus_clade_utils/util/session.py
+++ b/src/virus_clade_utils/util/session.py
@@ -8,24 +8,26 @@ from urllib3.util import Retry
 logger = structlog.get_logger()
 
 
-def _get_session() -> requests.Session:
+def _get_session(retry: bool = True) -> requests.Session:
     """Return a requests session with retry logic."""
 
     headers = {
         "Accept-Encoding": "br, deflate, gzip, x-xz, zstd",
+        "Accept": "application/json",
     }
-
     session = requests.Session()
-    # attach a urllib3 retry adapter to the requests session
-    # https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry
-    retries = Retry(
-        total=5,
-        allowed_methods=frozenset(["GET", "POST"]),
-        backoff_factor=1,
-        status_forcelist=[401, 403, 404, 429, 500, 502, 503, 504],
-    )
-    session.mount("https://", HTTPAdapter(max_retries=retries))
     session.headers.update(headers)
+
+    if retry:
+        # attach a urllib3 retry adapter to the requests session
+        # https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry
+        retries = Retry(
+            total=5,
+            allowed_methods=frozenset(["GET", "POST"]),
+            backoff_factor=1,
+            status_forcelist=[401, 403, 404, 429, 500, 502, 503, 504],
+        )
+        session.mount("https://", HTTPAdapter(max_retries=retries))
 
     return session
 

--- a/src/virus_clade_utils/util/session.py
+++ b/src/virus_clade_utils/util/session.py
@@ -3,12 +3,12 @@
 import requests
 import structlog
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry  # type: ignore
+from urllib3.util import Retry
 
 logger = structlog.get_logger()
 
 
-def _get_session(session: requests.Session = None) -> requests.Session:
+def _get_session() -> requests.Session:
     """Return a requests session with retry logic."""
 
     headers = {

--- a/src/virus_clade_utils/util/session.py
+++ b/src/virus_clade_utils/util/session.py
@@ -8,7 +8,7 @@ from requests.packages.urllib3.util.retry import Retry  # type: ignore
 logger = structlog.get_logger()
 
 
-def get_session(session: requests.Session = None) -> requests.Session:
+def _get_session(session: requests.Session = None) -> requests.Session:
     """Return a requests session with retry logic."""
 
     headers = {
@@ -30,7 +30,7 @@ def get_session(session: requests.Session = None) -> requests.Session:
     return session
 
 
-def check_response(response: requests.Response) -> bool:
+def _check_response(response: requests.Response) -> bool:
     """Check the results of a requests session."""
 
     if not response.ok:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,15 @@ from moto import mock_aws
 
 
 @pytest.fixture
+def s3_object_keys():
+    return {
+        "sequence_metadata": "data/object-key/metadata.tsv.zst",
+        "sequence": "data/object-key/sequences.fasta.zst",
+        "ncov_metadata": "data/object-key/metadata_version.json",
+    }
+
+
+@pytest.fixture
 def mock_session(mocker):
     """Session mock for testing functions that use requests.Session"""
     mock_session = mocker.patch.object(requests, "Session", autospec=True)
@@ -14,30 +23,35 @@ def mock_session(mocker):
 
 
 @pytest.fixture
-def s3_setup():
-    """Setup mock S3 bucket with versioned objects."""
+def s3_setup(s3_object_keys):
+    """
+    Setup mock S3 bucket with versioned objects that represent testing files for
+    sequence data, sequence metadata, and ncov pipeline metadata.
+    """
     with mock_aws():
         bucket_name = "versioned-bucket"
-        object_key = "metadata/object-key/metadata.tsv.zst"
 
         s3_client = boto3.client("s3", region_name="us-east-1")
         s3_client.create_bucket(Bucket=bucket_name)
         s3_client.put_bucket_versioning(Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"})
 
-        # Upload multiple versions of the object
-        versions = [
-            ("2023-01-01 03:05:01", "object version 1"),
-            ("2023-02-05 14:33:06", "object version 2"),
-            ("2023-03-22 22:55:12", "object version 3"),
-        ]
+        for file, object_key in s3_object_keys.items():
+            # Upload multiple versions of the object
+            versions = [
+                ("2023-01-01 03:05:01", f"{file} version 1"),
+                ("2023-02-05 03:33:06", f"{file} version 2"),
+                ("2023-02-05 14:33:06", f"{file} version 3"),
+                ("2023-03-22 22:55:12", f"{file} version 4"),
+            ]
 
-        for version_date, content in versions:
-            # use freezegun to override system date, which in
-            # turn sets S3 object version LastModified date
-            with freeze_time(version_date):
-                s3_client.put_object(
-                    Bucket=bucket_name,
-                    Key=object_key,
-                    Body=content,
-                )
-        yield s3_client, bucket_name, object_key
+            for version_date, content in versions:
+                # use freezegun to override system date, which in
+                # turn sets S3 object version LastModified date
+                with freeze_time(version_date):
+                    s3_client.put_object(
+                        Bucket=bucket_name,
+                        Key=object_key,
+                        Body=content,
+                    )
+
+        yield s3_client, bucket_name, s3_object_keys

--- a/tests/unit/test_cladetime.py
+++ b/tests/unit/test_cladetime.py
@@ -5,8 +5,8 @@ from urllib.parse import parse_qs, urlparse
 import dateutil.tz
 import pytest
 from freezegun import freeze_time
-from virus_clade_utils.cladetime import CladeTime  # type: ignore
-from virus_clade_utils.exceptions import CladeTimeInvalidDateError  # type: ignore
+from virus_clade_utils.cladetime import CladeTime
+from virus_clade_utils.exceptions import CladeTimeInvalidDateError
 from virus_clade_utils.util.config import Config
 
 

--- a/tests/unit/test_cladetime.py
+++ b/tests/unit/test_cladetime.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+
+import dateutil.tz
+import pytest
+from freezegun import freeze_time
+from virus_clade_utils.cladetime import CladeTime  # type: ignore
+from virus_clade_utils.exceptions import CladeTimeInvalidDateError  # type: ignore
+
+
+def test_cladetime_no_args():
+    with freeze_time("2024-12-13 16:21:34", tz_offset=-4):
+        ct = CladeTime()
+        expected_date = datetime.now(timezone.utc)
+    assert ct.tree_as_of == expected_date
+    assert ct.sequence_as_of == expected_date
+
+
+@pytest.mark.parametrize(
+    "sequence_as_of, tree_as_of, expected_sequence_as_of, expected_tree_as_of",
+    [
+        (
+            "2024-09-01",
+            "2024-01-01",
+            datetime(2024, 9, 1, tzinfo=timezone.utc),
+            datetime(2024, 1, 1, tzinfo=timezone.utc),
+        ),
+        (
+            None,
+            "2023-12-21",
+            datetime(2025, 7, 13, 16, 21, 34, tzinfo=timezone.utc),
+            datetime(2023, 12, 21, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2024, 9, 30, 18, 24, 59, 655398),
+            None,
+            datetime(2024, 9, 30, 18, 24, 59, tzinfo=timezone.utc),
+            datetime(2025, 7, 13, 16, 21, 34, tzinfo=timezone.utc),
+        ),
+        (
+            datetime(2024, 2, 22, 22, 22, 22, 222222, tzinfo=dateutil.tz.gettz("US/Eastern")),
+            datetime(2024, 2, 22, tzinfo=dateutil.tz.gettz("US/Eastern")),
+            datetime(2024, 2, 22, 22, 22, 22, tzinfo=timezone.utc),
+            datetime(2024, 2, 22, tzinfo=timezone.utc),
+        ),
+    ],
+)
+def test_cladetime_as_of_dates(sequence_as_of, tree_as_of, expected_sequence_as_of, expected_tree_as_of):
+    with freeze_time("2025-07-13 16:21:34"):
+        ct = CladeTime(sequence_as_of=sequence_as_of, tree_as_of=tree_as_of)
+
+    assert ct.sequence_as_of == expected_sequence_as_of
+    assert ct.tree_as_of == expected_tree_as_of
+
+
+@pytest.mark.parametrize("bad_date", ["2020-07-13", "2022-12-32", "2063-04-05"])
+def test_cladetime_invalid_date(bad_date):
+    with pytest.raises(CladeTimeInvalidDateError):
+        CladeTime(sequence_as_of=bad_date, tree_as_of=bad_date)

--- a/tests/unit/test_cladetime.py
+++ b/tests/unit/test_cladetime.py
@@ -109,3 +109,12 @@ def test_cladetime_urls(s3_setup, sequence_as_of, expected_content):
                 assert ct.url_ncov_metadata is None
             else:
                 assert ct.url_ncov_metadata is not None
+
+
+def test_cladetime_ncov_metadata():
+    ct = CladeTime()
+    ct.url_ncov_metadata = "https://httpstat.us/200"
+    assert ct.ncov_metadata == {"code": 200, "description": "OK"}
+
+    ct.url_ncov_metadata = "https://httpstat.us/504"
+    assert ct.ncov_metadata == {}

--- a/tests/unit/util/test_reference.py
+++ b/tests/unit/util/test_reference.py
@@ -15,9 +15,10 @@ def test_get_nextclade_dataset(tmp_path):
 
 
 def test__get_s3_object_url(s3_setup):
-    s3_client, bucket_name, object_key = s3_setup
+    s3_client, bucket_name, s3_object_keys = s3_setup
 
     target_date = datetime.strptime("2023-02-15", "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    object_key = s3_object_keys["sequence_metadata"]
 
     version_id, version_url = _get_s3_object_url(bucket_name, object_key, target_date)
 

--- a/tests/unit/util/test_reference.py
+++ b/tests/unit/util/test_reference.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from unittest import mock
 
-from virus_clade_utils.util.reference import get_nextclade_dataset, get_s3_object_url
+from virus_clade_utils.util.reference import _get_s3_object_url, get_nextclade_dataset
 
 
 @mock.patch("subprocess.run")
@@ -14,12 +14,12 @@ def test_get_nextclade_dataset(tmp_path):
     assert "2024-07-17--12-57-03Z" in str(dataset_path)
 
 
-def test_get_s3_object_url(s3_setup):
+def test__get_s3_object_url(s3_setup):
     s3_client, bucket_name, object_key = s3_setup
 
     target_date = datetime.strptime("2023-02-15", "%Y-%m-%d").replace(tzinfo=timezone.utc)
 
-    version_id, version_url = get_s3_object_url(bucket_name, object_key, target_date)
+    version_id, version_url = _get_s3_object_url(bucket_name, object_key, target_date)
 
     assert version_id is not None
     s3_object = s3_client.get_object(Bucket=bucket_name, Key=object_key, VersionId=version_id)

--- a/tests/unit/util/test_sequence.py
+++ b/tests/unit/util/test_sequence.py
@@ -63,16 +63,20 @@ def test_get_covid_genome_metadata(test_file_path, metadata_file):
 )
 def test_download_covid_genome_metadata(s3_setup, tmp_path, mock_session, as_of, filename):
     """Test filenames saved by covid genome metadata download."""
-    s3_client, bucket_name, object_key = s3_setup
-    actual_filename = download_covid_genome_metadata(mock_session, bucket_name, object_key, tmp_path, as_of=as_of)
+    s3_client, bucket_name, s3_object_keys = s3_setup
+    actual_filename = download_covid_genome_metadata(
+        mock_session, bucket_name, s3_object_keys["sequence_metadata"], tmp_path, as_of=as_of
+    )
     assert actual_filename.name == filename
 
 
 def test_download_covid_genome_metadata_no_history(s3_setup, tmp_path, mock_session):
     """Test genome metadata download where there is no history that matches the as_of date."""
-    s3_client, bucket_name, object_key = s3_setup
+    s3_client, bucket_name, s3_object_keys = s3_setup
     with pytest.raises(ValueError):
-        download_covid_genome_metadata(mock_session, bucket_name, object_key, tmp_path, as_of="2000-01-01")
+        download_covid_genome_metadata(
+            mock_session, bucket_name, s3_object_keys["sequence_metadata"], tmp_path, as_of="2000-01-01"
+        )
 
 
 def test_filter_covid_genome_metadata():


### PR DESCRIPTION
closes #20 

## Background
This PR addresses the issue above and also introduces a new class to simplify the interface for working with Nextstrain files: `CladeTime` (because we can get sequences and clade assignments at any point in time, get it?)

The only thing `CladeTime` currently does is instantiate with:

1.  a specific `as_of` date for both Sars-Cov-2 sequences/sequence metadata 
2.  a specific `as_of` date for the reference tree used to assign sequences to clades

`CladeTime` also has an `ncov_metadata` attribute, because that's what we need right now to get the variant nowcast hub ready.

## Review Notes
The commits are reasonably organized, so starting at the [first one](https://github.com/reichlab/virus-clade-utils/pull/26/commits/01563274c00d13b81b0fda7bf57be64ed70c27f3) and reviewing commit by commit is recommended.

## Demo
There's more information in the README, but to try `CladeTime` as a code reviewer, you'll need to install the package from this branch:

```bash
pip install "git+https://github.com/reichlab/virus-clade-utils.git@bsweger/get_nextstrain_ncov_metadata"
```

Then, from a Python console or script (the code below is what we'll add to [`get_clades_to_model.py` in the variant nowcast repo](https://github.com/reichlab/variant-nowcast-hub/blob/main/src/get_clades_to_model.py#L1), so we can save the metadata along with the clade list):

```python
from virus_clade_utils.cladetime import CladeTime
ct = CladeTime()
ct.ncov_metadata
```

The above should return a Python dictionary similar to:

```python
{
    "schema_version": "v1",
    "nextclade_version": "nextclade 3.8.2",
    "nextclade_dataset_name": "SARS-CoV-2",
    "nextclade_dataset_version": "2024-09-25--21-50-30Z",
    "nextclade_tsv_sha256sum": "fbe579554e925e4dfaf74cfb4e72b52c702e671f0f0374d896f1e30ae4fe5566",
    "metadata_tsv_sha256sum": "5a4fd84a5cd3c4ead9cf730d4df10b8734898c6c3e0cae1c8c0acf432325d22c",
}
```
