### PR TITLE
Add a sequence_metadata attribute to CladeTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,44 @@ In [1]: from virus_clade_utils.cladetime import CladeTime
 
 In [2]: ct = CladeTime()
 
-# URL for the corresponding Nextstrain Sars-Cov-2 sequence metadata
-In [3]: ct.url_sequence_metadata
-Out[3]: 'https://nextstrain-data.s3.amazonaws.com/files/ncov/open/metadata.tsv.zst?versionId=VJomXHLN2L9aqvS9Ax_LJ4ecr5ZsFFhE'
+# Return a Polars LazyFrame with the sequence metadata.
+In [4]: import polars as pl
 
-# Metadata from the pipeline that produced the above file
-In [4]: ct.ncov_metadata
-Out[4]:
+In [5]: lf = ct.sequence_metadata
+
+# From there, you can use Polars to manipulate the data as needed
+In [6]: filtered_sequence_metadata = (
+    lf
+    .select(["country", "division", "date", "host", "clade_nextstrain"])
+    .rename({"clade_nextstrain": "clade", "division": "location"})
+    .filter(
+        pl.col("country") == "USA",
+        pl.col("host") == "Homo sapiens"
+    )
+).collect()
+
+In [7]: filtered_sequence_metadata.head()
+Out[7]:
+shape: (5, 5)
+┌─────────┬──────────┬────────────┬──────────────┬───────┐
+│ country ┆ location ┆ date       ┆ host         ┆ clade │
+│ ---     ┆ ---      ┆ ---        ┆ ---          ┆ ---   │
+│ str     ┆ str      ┆ str        ┆ str          ┆ str   │
+╞═════════╪══════════╪════════════╪══════════════╪═══════╡
+│ USA     ┆ Alabama  ┆ 2022-07-07 ┆ Homo sapiens ┆ 22A   │
+│ USA     ┆ Arizona  ┆ 2022-07-02 ┆ Homo sapiens ┆ 22B   │
+│ USA     ┆ Arizona  ┆ 2022-07-19 ┆ Homo sapiens ┆ 22B   │
+│ USA     ┆ Arizona  ┆ 2022-07-15 ┆ Homo sapiens ┆ 22B   │
+│ USA     ┆ Arizona  ┆ 2022-07-20 ┆ Homo sapiens ┆ 22B   │
+└─────────┴──────────┴────────────┴──────────────┴───────┘
+
+# Pandas users can create a Pandas dataframe with sequence metadata
+
+In [8]: pandas = lf.collect().to_pandas()
+
+# Metadata from the pipeline that produced the above sequence_data
+In [9]: ct.ncov_metadata
+Out[9]:
 {'schema_version': 'v1',
  'nextclade_version': 'nextclade 3.8.2',
  'nextclade_dataset_name': 'SARS-CoV-2',
@@ -55,17 +86,17 @@ Out[4]:
  #### Work with point-in-time Nextstrain Sars-Cov-2 sequence metadata and clade assignments
 
  ```python
-In [5]: from virus_clade_utils.cladetime import CladeTime
+In [10]: from virus_clade_utils.cladetime import CladeTime
 
-In [6]: ct = CladeTime(sequence_as_of="2024-08-31", tree_as_of="2024-08-01")
+In [11]: ct = CladeTime(sequence_as_of="2024-08-31", tree_as_of="2024-08-01")
 
 # URL for the corresponding Nextstrain Sars-Cov-2 sequence metadata as it existing on 2024-08-31
-In [7]: ct.url_sequence_metadata
-Out[7]: 'https://nextstrain-data.s3.amazonaws.com/files/ncov/open/metadata.tsv.zst?versionId=1SZMfjWxXjNy530F6L7MfyflUCbue.JD'
+In [12]: ct.url_sequence_metadata
+Out[12]: 'https://nextstrain-data.s3.amazonaws.com/files/ncov/open/metadata.tsv.zst?versionId=1SZMfjWxXjNy530F6L7MfyflUCbue.JD'
 
 # Metadata for the pipeline run that produced the above file
-In [8]: ct.ncov_metadata
-Out[8]: {'schema_version': 'v1',
+In [13]: ct.ncov_metadata
+Out[13]: {'schema_version': 'v1',
  'nextclade_version': 'nextclade 3.8.2',
  'nextclade_dataset_name': 'SARS-CoV-2',
  'nextclade_dataset_version': '2024-07-17--12-57-03Z',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ filterwarnings = [
     "ignore::DeprecationWarning",
     'ignore:polars found a filename',
 ]
+testpaths = [
+    "tests",
+]
 
 [tool.ruff]
 line-length = 120

--- a/src/virus_clade_utils/_typing.py
+++ b/src/virus_clade_utils/_typing.py
@@ -1,0 +1,10 @@
+"""Type aliases for this package."""
+
+from pathlib import Path
+from typing import TypeAlias, Union
+
+from cloudpathlib import AnyPath, CloudPath
+
+# Data types
+# Pathlike: TypeAlias = Path | AnyPath | CloudPath
+Pathlike: TypeAlias = Union["Path", "AnyPath", "CloudPath"]

--- a/src/virus_clade_utils/cladetime.py
+++ b/src/virus_clade_utils/cladetime.py
@@ -2,12 +2,13 @@
 
 from datetime import datetime, timezone
 
+import polars as pl
 import structlog
 
 from virus_clade_utils.exceptions import CladeTimeInvalidDateError
 from virus_clade_utils.util.config import Config
 from virus_clade_utils.util.reference import _get_s3_object_url
-from virus_clade_utils.util.sequence import _get_ncov_metadata
+from virus_clade_utils.util.sequence import _get_ncov_metadata, get_covid_genome_metadata
 
 logger = structlog.get_logger()
 
@@ -25,6 +26,8 @@ class CladeTime:
     ncov_metadata : dict
         Metadata for the Nextstrain ncov pipeline that generated the sequence and
         sequence metadata that correspond to the sequence_as_of date.
+    metadata_metadata : pl.LazyFrame
+        A Polars lazyframe reference to url_sequence_metadata.
     tree_as_of : datetime
         Use the NextStrain reference tree that was available as of this
         date and time (UTC).
@@ -58,6 +61,7 @@ class CladeTime:
         self.sequence_as_of = self._validate_as_of_date(sequence_as_of)
         self.tree_as_of = self._validate_as_of_date(tree_as_of)
         self._ncov_metadata = {}
+        self._sequence_metadata = pl.LazyFrame()
 
         self.url_sequence = _get_s3_object_url(
             self._config.nextstrain_ncov_bucket, self._config.nextstrain_genome_sequence_key, self.sequence_as_of
@@ -87,6 +91,20 @@ class CladeTime:
         else:
             metadata = {}
         return metadata
+
+    @property
+    def sequence_metadata(self):
+        return self._sequence_metadata
+
+    @sequence_metadata.getter
+    def sequence_metadata(self) -> pl.LazyFrame:
+        """Set the sequence_metadata attribute."""
+        if self.url_sequence_metadata:
+            sequence_metadata = get_covid_genome_metadata(metadata_url=self.url_sequence_metadata)
+            return sequence_metadata
+        else:
+            sequence_metadata = pl.LazyFrame()
+        return sequence_metadata
 
     def __repr__(self):
         return f"CladeTime(sequence_as_of={self.sequence_as_of}, tree_as_of={self.tree_as_of})"

--- a/src/virus_clade_utils/cladetime.py
+++ b/src/virus_clade_utils/cladetime.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import polars as pl
 import structlog
 
-from virus_clade_utils.exceptions import CladeTimeInvalidDateError
+from virus_clade_utils.exceptions import CladeTimeInvalidDateError, CladeTimeInvalidURLError
 from virus_clade_utils.util.config import Config
 from virus_clade_utils.util.reference import _get_s3_object_url
 from virus_clade_utils.util.sequence import _get_ncov_metadata, get_covid_genome_metadata
@@ -103,7 +103,7 @@ class CladeTime:
             sequence_metadata = get_covid_genome_metadata(metadata_url=self.url_sequence_metadata)
             return sequence_metadata
         else:
-            sequence_metadata = pl.LazyFrame()
+            raise CladeTimeInvalidURLError("CladeTime is missing url_sequence_metadata")
         return sequence_metadata
 
     def __repr__(self):

--- a/src/virus_clade_utils/exceptions.py
+++ b/src/virus_clade_utils/exceptions.py
@@ -7,3 +7,7 @@ class Error(Exception):
 
 class CladeTimeInvalidDateError(Error):
     """Raised when an invalid date string is passed to CladeTime."""
+
+
+class CladeTimeInvalidURLError(Error):
+    """Raised when CladeTime encounters an invalid URL."""

--- a/tests/unit/test_cladetime.py
+++ b/tests/unit/test_cladetime.py
@@ -6,7 +6,7 @@ import dateutil.tz
 import pytest
 from freezegun import freeze_time
 from virus_clade_utils.cladetime import CladeTime
-from virus_clade_utils.exceptions import CladeTimeInvalidDateError
+from virus_clade_utils.exceptions import CladeTimeInvalidDateError, CladeTimeInvalidURLError
 
 
 def test_cladetime_no_args():
@@ -124,5 +124,6 @@ def test_cladetime_sequence_metadata_no_url(test_config):
     with patch("virus_clade_utils.cladetime.CladeTime._get_config", mock):
         ct = CladeTime()
     ct.url_sequence_metadata = None
-    # if there's no metadata url, sequence metadata should be an empty LazyFrame
-    assert ct.sequence_metadata.collect().shape == (0, 0)
+
+    with pytest.raises(CladeTimeInvalidURLError):
+        ct.sequence_metadata

--- a/tests/unit/util/test_sequence.py
+++ b/tests/unit/util/test_sequence.py
@@ -54,6 +54,19 @@ def test_get_covid_genome_metadata(test_file_path, metadata_file):
     assert expected_cols.issubset(metadata_cols)
 
 
+@pytest.mark.parametrize("metadata_file", ["metadata.tsv.zst", "metadata.tsv.xz"])
+def test_get_covid_genome_metadata_url(s3_setup, test_file_path, metadata_file):
+    """
+    Test get_covid_genome_metadata when used with an S3 URL instead of a local file.
+    Needs additional research into moto and S3 url access.
+    """
+    s3_client, bucket_name, s3_object_keys = s3_setup
+
+    url = f"https://{bucket_name}.s3.amazonaws.com/data/object-key/{metadata_file}"
+    metadata = get_covid_genome_metadata(metadata_url=url)
+    assert isinstance(metadata, pl.LazyFrame)
+
+
 @pytest.mark.parametrize(
     "as_of, filename",
     [


### PR DESCRIPTION
## Background

This is the first step towards saving daily sequence counts by location: https://github.com/reichlab/variant-nowcast-hub/issues/50

We don't _have_ to download sequence metadata files from S3 before working with them, so this PR adds an attribute to the `CladeTime` class that exposes a Polars LazyFrame pointing to a Nextstrain sequence metdata file.

## Next Step

Once this new feature is merged, we can add code to `variant-nowcast-hub` to instantiate a `CladeTime` object and use the LazyFrame reference to create the location/data information outlined in the above issue.

## Testing

To test this new feature as a code reviewer, you'll need to install `virus_clade_utils` from this feature branch:

```
pip install "git+https://github.com/reichlab/virus-clade-utils.git@bsweger/sequence-by-state-date/50"
```

Then from a Python session:

```python
import polars as pl
from virus_clade_utils.cladetime import CladeTime

# Get a CladeTime object for the most recent Nextstrain sequence metadata
ct = CladeTime()

# ct.sequence_metadata is the new attribute (a LazyFrame)
filtered_metadata = (
    ct.sequence_metadata
    .select(["country", "division", "host", "date", "clade_nextstrain"])
    .filter(
        pl.col("country") == "USA"
     )
).collect()
```





