### PR TITLE
Improvements to logging and timing

### DIFF
--- a/src/virus_clade_utils/__init__.py
+++ b/src/virus_clade_utils/__init__.py
@@ -5,14 +5,8 @@ import structlog
 
 def setup_logging():
     shared_processors = [
-        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S"),
         structlog.processors.add_log_level,
-        structlog.processors.CallsiteParameterAdder(
-            [
-                structlog.processors.CallsiteParameter.FILENAME,
-                structlog.processors.CallsiteParameter.LINENO,
-            ]
-        ),
     ]
 
     if sys.stderr.isatty():

--- a/src/virus_clade_utils/get_clade_list.py
+++ b/src/virus_clade_utils/get_clade_list.py
@@ -1,7 +1,6 @@
 """Get a list of SARS-CoV-2 clades."""
 
 import os
-import time
 from datetime import timedelta
 
 import polars as pl
@@ -16,13 +15,14 @@ from virus_clade_utils.util.sequence import (
     get_covid_genome_metadata,
 )
 from virus_clade_utils.util.session import _get_session
+from virus_clade_utils.util.timing import time_function
 
 logger = structlog.get_logger()
 
 
+@time_function
 def get_clades(clade_counts: pl.LazyFrame, threshold: float, threshold_weeks: int, max_clades: int) -> list[str]:
     """Get a list of clades to forecast based."""
-    start = time.perf_counter()
 
     # based on the data's most recent date, get the week start three weeks ago (not including this week)
     max_day = clade_counts.select(pl.max("date")).collect().item()
@@ -59,10 +59,6 @@ def get_clades(clade_counts: pl.LazyFrame, threshold: float, threshold_weeks: in
         )
 
     variants = high_prev_variants.get_column("clade").to_list()[:max_clades]
-
-    end = time.perf_counter()
-    elapsed = end - start
-    logger.info("generated clade list", elapsed=elapsed)
 
     return variants
 

--- a/src/virus_clade_utils/util/sequence.py
+++ b/src/virus_clade_utils/util/sequence.py
@@ -174,14 +174,13 @@ def filter_covid_genome_metadata(metadata: pl.LazyFrame, cols: list = []) -> pl.
             "host",
         ]
 
-    # There are some other odd divisions in the data, but these are 50 states and DC
+    # There are some other odd divisions in the data, but these are 50 states, DC and PR
     states = [state.name for state in us.states.STATES]
     states.extend(["Washington DC", "Puerto Rico"])
 
     # Filter dataset and do some general tidying
     filtered_metadata = (
-        metadata.cast({"date": pl.Date}, strict=False)
-        .select(cols)
+        metadata.select(cols)
         .filter(
             pl.col("country") == "USA",
             pl.col("division").is_in(states),
@@ -189,6 +188,7 @@ def filter_covid_genome_metadata(metadata: pl.LazyFrame, cols: list = []) -> pl.
             pl.col("host") == "Homo sapiens",
         )
         .rename({"clade_nextstrain": "clade", "division": "location"})
+        .cast({"date": pl.Date}, strict=False)
     )
 
     return filtered_metadata

--- a/src/virus_clade_utils/util/sequence.py
+++ b/src/virus_clade_utils/util/sequence.py
@@ -2,7 +2,6 @@
 
 import json
 import lzma
-import time
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,10 +13,12 @@ from requests import Session
 
 from virus_clade_utils.util.reference import _get_s3_object_url
 from virus_clade_utils.util.session import _check_response, _get_session
+from virus_clade_utils.util.timing import time_function
 
 logger = structlog.get_logger()
 
 
+@time_function
 def get_covid_genome_data(released_since_date: str, base_url: str, filename: str):
     """
     Download genome data package from NCBI.
@@ -48,7 +49,6 @@ def get_covid_genome_data(released_since_date: str, base_url: str, filename: str
 
     logger.info("NCBI API call starting", released_since_date=released_since_date)
 
-    start = time.perf_counter()
     response = session.post(base_url, data=json.dumps(request_body), timeout=(300, 300))
     _check_response(response)
 
@@ -60,12 +60,8 @@ def get_covid_genome_data(released_since_date: str, base_url: str, filename: str
     with open(filename, "wb") as f:
         f.write(response.content)
 
-    end = time.perf_counter()
-    elapsed = end - start
 
-    logger.info("NCBI API call completed", elapsed=elapsed)
-
-
+@time_function
 def download_covid_genome_metadata(
     session: Session, bucket: str, key: str, data_path: Path, as_of: str | None = None, use_existing: bool = False
 ) -> Path:
@@ -83,17 +79,12 @@ def download_covid_genome_metadata(
         logger.info("using existing genome metadata file", metadata_file=str(filename))
         return filename
 
-    start = time.perf_counter()
     logger.info("starting genome metadata download", source=s3_url, destination=str(filename))
     with session.get(s3_url, stream=True) as result:
         result.raise_for_status()
         with open(filename, "wb") as f:
             for chunk in result.iter_content(chunk_size=None):
                 f.write(chunk)
-
-    end = time.perf_counter()
-    elapsed = end - start
-    logger.info("genome metadata downloaded", elapsed=elapsed)
 
     return filename
 

--- a/src/virus_clade_utils/util/timing.py
+++ b/src/virus_clade_utils/util/timing.py
@@ -1,0 +1,21 @@
+"""Code to support the timing of functions."""
+
+import functools
+import time
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+def time_function(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        start_time = time.perf_counter()
+        value = func(*args, **kwargs)
+        end_time = time.perf_counter()
+        run_time = end_time - start_time
+        logger.info(f"{repr(func.__name__)} complete", elapsed_seconds=round(run_time, ndigits=2))
+        return value
+
+    return wrapper


### PR DESCRIPTION
This PR contains a few non-critical updates to the code base:

1. Slight re-order to the Polars operations in `filter_covid_genome_metadata`
2. Improve readibility of the log output
3. Add a re-usable decorator for timing functions
